### PR TITLE
feat: apply ssr

### DIFF
--- a/onebite-challenge-cinema/src/lib/fetch-movies.ts
+++ b/onebite-challenge-cinema/src/lib/fetch-movies.ts
@@ -1,0 +1,17 @@
+import {MovieData} from "@/types";
+
+export default async function fetchMovies(q?: string): Promise<MovieData[]> {
+    let url = `http://localhost:12345/movie`;
+
+    if(q){
+        url += `/search?q=${q}`;
+    }
+
+    try {
+        const response = await fetch(url);
+        return await response.json();
+    } catch (err) {
+        console.error(err);
+        return [];
+    }
+}

--- a/onebite-challenge-cinema/src/lib/fetch-one-movies.ts
+++ b/onebite-challenge-cinema/src/lib/fetch-one-movies.ts
@@ -1,0 +1,13 @@
+import {MovieData} from "@/types";
+
+export default async function fetchOneMovies(id?: number): Promise<MovieData | null> {
+    let url = `http://localhost:12345/movie/${id}`;
+
+    try {
+        const response = await fetch(url);
+        return await response.json();
+    } catch (err) {
+        console.error(err);
+        return null;
+    }
+}

--- a/onebite-challenge-cinema/src/lib/fetch-random-books.ts
+++ b/onebite-challenge-cinema/src/lib/fetch-random-books.ts
@@ -1,0 +1,15 @@
+import {MovieData} from "@/types";
+
+export default async function fetchRandomMovies(): Promise<MovieData[]> {
+    const url = "http://localhost:12345/movie/random";
+
+    try {
+        const response = await fetch(url);
+        return await response.json();
+    } catch (err) {
+
+        console.log(err);
+        return [];
+    }
+
+};

--- a/onebite-challenge-cinema/src/pages/index.tsx
+++ b/onebite-challenge-cinema/src/pages/index.tsx
@@ -1,16 +1,34 @@
 import SearchBar from "@/components/Search-bar";
 import MovieItem from "@/components/Movie-item";
-import movies from "@/dummy.json";
 import style from './index.module.css';
+import fetchMovies from "@/lib/fetch-movies";
+import fetchRandomMovies from "@/lib/fetch-random-books";
+import {InferGetServerSidePropsType} from "next";
 
-export default function Home() {
+export const getServerSideProps = async () => {
+    const [allMovies, recoMovies] =
+        await Promise.all([
+            fetchMovies(),
+            fetchRandomMovies()
+        ]);
+
+    return {
+        props: {
+            allMovies,
+            recoMovies,
+        },
+    };
+};
+
+
+export default function Home({allMovies, recoMovies}: InferGetServerSidePropsType<typeof getServerSideProps>) {
     return (
         <div className={style.container}>
             <SearchBar/>
             <div>
                 <div>지금 가장 추천하는 영화</div>
                 <div className={style.reco_container}>
-                    {movies.slice(0, 3).map((movie) => (
+                    {recoMovies.map((movie) => (
                         <MovieItem key={`recomovie-${movie.id}`} {...movie} />
                     ))}
                 </div>
@@ -18,11 +36,11 @@ export default function Home() {
             <div>
                 <div>등록된 모든 영화</div>
                 <div className={style.all_container}>
-                    {movies.map((movie) => (
+                    {allMovies.map((movie) => (
                         <MovieItem key={`movie-${movie.id}`} {...movie} />
                     ))}
                 </div>
             </div>
         </div>
     );
-}
+};

--- a/onebite-challenge-cinema/src/pages/movie/[id].tsx
+++ b/onebite-challenge-cinema/src/pages/movie/[id].tsx
@@ -1,22 +1,22 @@
 import {useRouter} from "next/router";
 import {MovieData} from "@/types";
 import style from './[id].module.css';
+import {GetServerSidePropsContext, InferGetServerSidePropsType} from "next";
+import fetchOneMovie from "@/lib/fetch-one-movies";
 
-const movie: MovieData = {
-    id: 1022789,
-    title: "인사이드 아웃 2",
-    releaseDate: "2024-06-11",
-    company: "Walt Disney Pictures, Pixar",
-    genres: ["애니메이션", "가족", "모험", "코미디"],
-    subTitle: "비상! 새로운 감정들이 몰려온다!",
-    description:
-        "13살이 된 라일리의 행복을 위해 매일 바쁘게 머릿속 감정 컨트롤 본부를 운영하는 ‘기쁨’, ‘슬픔’, ‘버럭’, ‘까칠’, ‘소심’. 그러던 어느 날, 낯선 감정인 ‘불안’, ‘당황’, ‘따분’, ‘부럽’이가 본부에 등장하고, 언제나 최악의 상황을 대비하며 제멋대로인 ‘불안’이와 기존 감정들은 계속 충돌한다. 결국 새로운 감정들에 의해 본부에서 쫓겨나게 된 기존 감정들은 다시 본부로 돌아가기 위해 위험천만한 모험을 시작하는데…",
-    runtime: 97,
-    posterImgUrl:
-        "https://media.themoviedb.org/t/p/w300_and_h450_face/pmemGuhr450DK8GiTT44mgwWCP7.jpg",
-};
+export const getServerSideProps = async(context: GetServerSidePropsContext) => {
+    const id = context.params!.id;
+    const movie = await fetchOneMovie(Number(id));
 
-export default function Page() {
+    return {
+        props: {
+            movie,
+        }
+    }
+}
+export default function Page({movie}: InferGetServerSidePropsType<typeof getServerSideProps>) {
+    if (!movie) return <div>영화 정보가 없습니다.</div>;
+
     const {
         id,
         title,

--- a/onebite-challenge-cinema/src/pages/search/index.tsx
+++ b/onebite-challenge-cinema/src/pages/search/index.tsx
@@ -1,23 +1,33 @@
 import {useRouter} from "next/router";
 import SearchBar from "@/components/Search-bar";
-import movies from "@/dummy.json";
 import MovieItem from "@/components/Movie-item";
-import {MovieData} from "@/types";
 import style from './index.module.css';
+import {GetServerSidePropsContext, InferGetServerSidePropsType} from "next";
+import fetchMovies from "@/lib/fetch-movies";
 
-export default function Page() {
+
+export const getServerSideProps = async (context: GetServerSidePropsContext) => {
+    const q = context.query.q as string;
+
+    const searchMovies = await fetchMovies(q);
+
+    return {
+        props: {
+            searchMovies,
+        }
+    }
+}
+
+export default function Page({searchMovies}: InferGetServerSidePropsType<typeof getServerSideProps>) {
 
     const router = useRouter();
-    const {q} = router.query;
 
     return (
         <div>
             <SearchBar/>
-            {q && (
+            {searchMovies && (
                 <div className={style.search_container}>
-                    {movies.filter(
-                        (movie: MovieData) => movie.title.includes(q as string)
-                    ).map((movie) => (
+                    {searchMovies.map((movie) => (
                         <MovieItem key={movie.id} {...movie} />
                     ))}
                 </div>


### PR DESCRIPTION
# [ Day 06 ] Next.js 미션

## 🗓️ 오늘의 진도
Next.js 에서의 데이터 페칭 방법

[전체 진도표 보기](https://winterlood.notion.site/Next-js-2d88c12bf13041dab85068953a5a78a0?pvs=4)

2.12 SSR2. 실습까지 수강합니다.
3개의 챕터 / 50분 소요

## 미션 소개) 한입-씨네마 SSR 적용하기 (with 데이터 페칭)
"한입 씨네마" 프로젝트의 데이터 페칭 기능을 구현하고, SSR로 데이터를 불러오도록 설정합니다. 아래 안내드리는 순서에 따라 미션을 수행해주세요

1. 인덱스 페이지 데이터 페칭 구현하기 (SSR)
SSR 방식으로 인덱스 페이지에 필요한 다음 2개의 데이터를 불러오도록 설정합니다.
데이터 요청 주소는 API 문서를 참고하세요

recoMovies : 3개의 추천 영화 데이터를 불러옵니다.
allMovies : 전체 영화 데이터를 불러옵니다.
데이터를 불러오는 함수는 lib 폴더에 별도로 생성하는 것을 권장드리며
불러온 데이터를 실제로 화면에 렌더링까지 해 주시면 됩니다.

Hint. 여러개의 API를 요청 할때에는 병렬로 요청을 발송해주는 Promise.all을 사용해보세요!

2. 서치 페이지 데이터 페칭 구현하기 (SSR)
검색 결과 데이터를 API 서버로부터 불러와 렌더링합니다.
데이터 요청 주소는 API 문서를 참고하세요

3. 영화 상세 페이지 데이터 페칭 구현하기 (SSR)
하나의 영화 데이터를 API 서버로부터 불러와 렌더링 합니다.
데이터 요청 주소는 API 문서를 참고하세요